### PR TITLE
Fix unescaped single quotes in olmconfig.yaml

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -13,7 +13,7 @@ description: |-
   **About Amazon Lambda Microvms**
 
 
-  If you're building an application where multiple users or AI agents connect to a compute environment and run code (for e.g. interactive development environments, CI/CD systems, or sandboxes for AI) – you need compute environments that start fast, stay isolated between tenants, and don't require you to manage servers or networking.
+  If you''re building an application where multiple users or AI agents connect to a compute environment and run code (for e.g. interactive development environments, CI/CD systems, or sandboxes for AI) – you need compute environments that start fast, stay isolated between tenants, and don''t require you to manage servers or networking.
 
   AWS Lambda MicroVMs are purpose-built for these use cases. They are serverless compute environments that provide VM-level isolation with full operating system capabilities (for e.g. installing system packages or mounting filesystems), snapshot-based rapid startup speeds, and fine-grained control over ingress networking (port access, support for HTTP/2, gRPC, WebSockets) and egress networking (public internet access and VPC access).
 


### PR DESCRIPTION
Issue #, if available: [2959](https://github.com/aws-controllers-k8s/community/issues/2959)

Description of changes:
Un-escaped single quotes in olmconfig.yaml resulted in `ack-generate olm` generating invalid YAML for OLM manifests. Adding escaping and validated that `ackgenerate olm` and `create-olm-bundle.sh` run successfully.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
